### PR TITLE
Update bootsy.gemspec

### DIFF
--- a/bootsy.gemspec
+++ b/bootsy.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*'] + ['MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.add_dependency 'mini_magick', '~> 3.6.0'
-  s.add_dependency 'carrierwave', '~> 0.9.0'
+  s.add_dependency 'mini_magick'
+  s.add_dependency 'carrierwave'
   s.add_dependency 'remotipart', '~> 1.2.1'
 
   s.add_development_dependency 'rspec-rails', '~> 2.14'


### PR DESCRIPTION
Bundler could not find compatible versions for gem "mini_magick":
  In snapshot (Gemfile.lock):
    mini_magick (= 3.8.1)

  In Gemfile:
    bootsy (>= 0) ruby depends on
      mini_magick (~> 3.6.0) ruby

```
mini_magick (>= 0) ruby
```
